### PR TITLE
Add console.dir Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sumologic",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Sync Application logs to sumo logic directly via their http API",
   "main": "sumo.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "homepage": "https://github.com/helix-collective/node-sumologic#readme",
   "dependencies": {
-    "request": "2.69.0",
+    "request": "2.74.0",
     "underscore": "1.8.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
+    "mocha": "^2.5.3",
+    "sinon": "^1.17.5"
   }
 }

--- a/sumo.js
+++ b/sumo.js
@@ -22,43 +22,52 @@ module.exports = function SumoLogger(collectorCode, opts) {
   var request = opts.request || require('request');
   var collectorEndpoint = endpoint + collectorCode;
   var syncInterval = opts.syncInterval || 1000;
+  var timestamps = opts.timestamps || false;
 
   me.stdConsole = {
-    log: console.log,
-    info: console.info,
+    dir: console.warn,
     error: console.error,
-    warn: console.warn
+    info: console.info,
+    log: console.log,
+    warn: console.warn,
   }
+
   me.replaceConsole = function() {
-    console.log = me.log;
-    console.info = me.info;
+    console.dir = me.dir;
     console.error = me.error;
+    console.info = me.info;
+    console.log = me.log;
     console.warn = me.warn;
   }
 
   me.restoreConsole = function() {
-    console.log = me.stdConsole.log;
-    console.info = me.stdConsole.info;
+    console.dir = me.stdConsole.dir;
     console.error = me.stdConsole.error;
+    console.info = me.stdConsole.info;
+    console.log = me.stdConsole.log;
     console.warn = me.stdConsole.warn;
   }
 
   me.augmentConsole = function() {
-      console.log = function() {
-          me.stdConsole.log.apply(this, arguments);
-          me.log.apply(this, arguments);
+      console.dir = function() {
+          me.stdConsole.dir.apply(this, arguments);
+          me.dir.apply(this, arguments);
+      }
+      console.error = function() {
+          me.stdConsole.error.apply(this, arguments);
+          me.error.apply(this, arguments);
       }
       console.info = function() {
           me.stdConsole.info.apply(this, arguments);
           me.info.apply(this, arguments);
       }
+      console.log = function() {
+          me.stdConsole.log.apply(this, arguments);
+          me.log.apply(this, arguments);
+      }
       console.warn = function() {
           me.stdConsole.warn.apply(this, arguments);
           me.warn.apply(this, arguments);
-      }
-      console.error = function() {
-          me.stdConsole.error.apply(this, arguments);
-          me.error.apply(this, arguments);
       }
   }
 
@@ -84,9 +93,10 @@ module.exports = function SumoLogger(collectorCode, opts) {
   }
 
   // I want arguments to be treated as an object (helps indexing into the correct fields on sumo logic)
-  me.log = function() { append('INFO', arguments); };
-  me.info = function() { append('INFO', arguments); };
+  me.dir = function() { append('DIR', arguments); };
   me.error = function() { append('ERROR', arguments); };
+  me.info = function() { append('INFO', arguments); };
+  me.log = function() { append('INFO', arguments); };
   me.warn = function() { append('WARN', arguments); };
 
   var numBeingSent = 0;

--- a/test/sumo-test.js
+++ b/test/sumo-test.js
@@ -219,7 +219,7 @@ describe('Sumo Logic Collector', function() {
     check([1,2,3,4]);
   });
 
-  it("Augments console.log correctly", function () {
+  it("Augments console correctly", function () {
     var expected = {};
     var sumologic = newTestSumoLogger(function(opts, cb) {
       expect(JSON.parse(opts.body)).to.deep.equal({level: "INFO", data: expected});
@@ -250,5 +250,11 @@ describe('Sumo Logic Collector', function() {
     console.error("msg 1", "msg 2");
     expect(sumologic.error.calledOnce, 'sumo/error').to.equal(true);
     expect(sumologic.stdConsole.error.calledOnce, 'console/error').to.equal(true);
+
+    sinon.spy(sumologic, 'dir');
+    sinon.spy(sumologic.stdConsole, 'dir');
+    console.dir("msg 1", "msg 2");
+    expect(sumologic.dir.calledOnce, 'sumo/dir').to.equal(true);
+    expect(sumologic.stdConsole.dir.calledOnce, 'console/dir').to.equal(true);
   });
 });


### PR DESCRIPTION
This is only partial support, but is better than nothing at all. The second argument of `dir` where you can specify depth currently just gets sent to Sumo. I'd be interested in hearing whether or not you think we should add `JSON.stringify(arguments[0], null, 4)` possibly to the dir augment.